### PR TITLE
Add max-height feature

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,12 +7,17 @@ export default class extends Controller {
   onResize: EventListenerOrEventListenerObject // eslint-disable-line no-undef
 
   resizeDebounceDelayValue: number
+  maxHeightValue: number
 
   static values = {
     resizeDebounceDelay: {
       type: Number,
       default: 100
-    }
+    },
+    maxHeight: {
+      type: Number,
+      default: 0,
+    },
   }
 
   initialize (): void {
@@ -37,6 +42,13 @@ export default class extends Controller {
 
   autogrow (): void {
     this.element.style.height = 'auto' // Force re-print before calculating the scrollHeight value.
-    this.element.style.height = `${this.element.scrollHeight}px`
+
+    const [heightVal, overflowVal] =
+      this.maxHeightValue > 0 && this.element.scrollHeight >= this.maxHeightValue
+        ? [this.maxHeightValue, "scroll"] // Stop autogrow and enable scrolling
+        : [this.element.scrollHeight, "hidden"]
+
+    this.element.style.height = `${heightVal}px`
+    this.element.style.overflow = overflowVal
   }
 }


### PR DESCRIPTION
I added a feature of max height so the textarea doesn't grow past that. After max-height the overflow style switches to scroll and it switches back to hidden if you delete enough lines.

To use max-height you put the attribute 'data-textarea-autogrow-max-height-value' on the html textarea element.